### PR TITLE
Assign prev_results to correct member in TrasnportOperator's constructor

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -122,7 +122,7 @@ class TransportOperator(ABC):
             self.prev_res = None
         else:
             check_type("previous results", prev_results, ResultsList)
-            self.prev_results = prev_results
+            self.prev_res = prev_results
 
     @property
     def dilute_initial(self):

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -183,7 +183,6 @@ class Operator(TransportOperator):
                 "or fission-q".format(energy_mode))
         super().__init__(chain_file, fission_q, dilute_initial, prev_results)
         self.round_number = False
-        self.prev_res = None
         self.settings = settings
         self.geometry = geometry
         self.diff_burnable_mats = diff_burnable_mats


### PR DESCRIPTION
a little more fix to keep user-supplied prev_results on operator #1610